### PR TITLE
Bug fix - Auth component -> service

### DIFF
--- a/generators/app/templates/src/components/Auth/service.ts
+++ b/generators/app/templates/src/components/Auth/service.ts
@@ -60,7 +60,7 @@ const AuthService: IAuthService = {
                 email: body.email
             });
         
-            const isMatched: boolean = await user.comparePassword(body.password);
+            const isMatched: boolean = user && await user.comparePassword(body.password);
  
             if (isMatched) {
                 return user;


### PR DESCRIPTION
When a user is not found, the user.comparePassword will still execute resulting in a bogus error message back to the client.  Fix is to verify the user before executing the await to verify password.